### PR TITLE
Update composer.json to be compatible with the Composer autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "simpletest/simpletest": "*"
   },
   "autoload": {
-    "classmap": ["lib/Taxamo/", "lib/Taxamo.php"]
+    "classmap": ["lib/Taxamo/"],
+    "files": ["lib/Taxamo.php"]
   }
 }

--- a/test/TaxamoTest.php
+++ b/test/TaxamoTest.php
@@ -24,7 +24,7 @@ function exception_error_handler($errno, $errstr, $errfile, $errline)
 set_error_handler('exception_error_handler');
 error_reporting(E_ALL | E_STRICT);
 
-require_once(dirname(__FILE__) . '/../lib/Taxamo.php');
+require_once(dirname(__FILE__) . '/../vendor/autoload.php');
 require_once(dirname(__FILE__) . '/TaxamoTest/Common.php');
 
 require_once(dirname(__FILE__) . '/TaxamoTest/TestTaxApi.php');


### PR DESCRIPTION
`files` section is required to be compatible with the Composer autoload. Composer attempts to include Taxamo.php multiple times otherwise and causes a `Cannot redeclare Taxamo\startsWith()` error when trying to use the Taxamo API